### PR TITLE
Fix a CastException with Citizens

### DIFF
--- a/src/main/java/com/lenis0012/bukkit/npc/NPCFactory.java
+++ b/src/main/java/com/lenis0012/bukkit/npc/NPCFactory.java
@@ -55,8 +55,7 @@ public class NPCFactory implements Listener {
 		}
 		
 		try {
-			NPCEntity npcEntity = (NPCEntity) ((CraftEntity) entity).getHandle();
-			return npcEntity;
+			return (NPCEntity) ((CraftEntity) entity).getHandle();
 		} catch(Exception ignored) {
 			return null;
 		}


### PR DESCRIPTION
On interact, the plugin tries to cast Citizens NPCs to NPCEntity which throws a CastException.
